### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,7 @@ module.exports = {
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
+    new ExtractTextPlugin("styles.css"),
     new webpack.optimize.CommonsChunkPlugin({
       names: ['vendor', 'manifest']
     }),


### PR DESCRIPTION
Adding ExtractTextPlugin to plugins list to resolve following error:

Module build failed: Error: "extract-text-webpack-plugin" loader is used without the corresponding plugin, refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example